### PR TITLE
fix impression count URL parameter

### DIFF
--- a/campaign_info.toml
+++ b/campaign_info.toml
@@ -6,13 +6,13 @@ wrapper_template = "wikipedia_org"
 
 [aktionswoche.banners.ctrl]
 filename = "./wikipedia_aktionswoche/banner_ctrl.js"
-pagename = "B20WMDE_aktionswoche_spring2021_ctrl"
+pagename = "B21WMDE_wp20_aw_b2_desktop"
 tracking = "WMDE_wp20_aw_b2_desktop"
 
 [aktionswoche.banners.var]
 filename = "./wikipedia_aktionswoche/banner_var.js"
-pagename = "B20WMDE_aktionswoche_spring2021_var"
-tracking = "WMDE_wp20_aw_b2_desktop_var"
+pagename = "B21WMDE_wp20_aw_b1_desktop"
+tracking = "WMDE_wp20_aw_b1_desktop"
 
 [aktionswoche_mobile]
 campaign_tracking = "WMDE_wp20_aw"
@@ -21,13 +21,28 @@ wrapper_template = "wikipedia_org"
 
 [aktionswoche_mobile.banners.ctrl]
 filename = "./wikipedia_aktionswoche/banner_ctrl.js"
-pagename = "B20WMDE_aktionswoche_spring2021_ctrl_m"
+pagename = "B21WMDE_wp20_aw_b2_mobile"
 tracking = "WMDE_wp20_aw_b2_mobile"
 
 [aktionswoche_mobile.banners.var]
 filename = "./wikipedia_aktionswoche/banner_var.js"
-pagename = "B20WMDE_aktionswoche_spring2021_var_m"
-tracking = "WMDE_wp20_aw_b2_mobile_var"
+pagename = "B21WMDE_wp20_aw_b1_mobile"
+tracking = "WMDE_wp20_aw_b1_mobile"
+
+[aktionswoche_ipad]
+campaign_tracking = "WMDE_wp20_aw"
+preview_link = "/wiki/Wikipedia:Hauptseite?useskin=Minerva&banner=B17WMDE_webpack_prototype&devbanner={{banner}}"
+wrapper_template = "wikipedia_org"
+
+[aktionswoche_ipad.banners.ctrl]
+filename = "./wikipedia_aktionswoche/banner_ctrl.js"
+pagename = "B21WMDE_wp20_aw_b2_ipad"
+tracking = "WMDE_wp20_aw_b2_ipad"
+
+[aktionswoche_ipad.banners.var]
+filename = "./wikipedia_aktionswoche/banner_var.js"
+pagename = "B21WMDE_wp20_aw_b1_ipad"
+tracking = "WMDE_wp20_aw_b1_ipad"
 
 # Wikipedia-Challenge
 [challenge]

--- a/wikipedia_aktionswoche/Banner.js
+++ b/wikipedia_aktionswoche/Banner.js
@@ -41,7 +41,6 @@ export class Banner {
 		this.templateVars = templateVars;
 
 		this.localImpressionCount = new LocalImpressionCount( this.name );
-		this.templateVars.impression_count = this.localImpressionCount.getImpressionCount();
 		this.eventLoggingTracker = new EventLoggingTracker( this.name, this.localImpressionCount );
 	}
 
@@ -91,6 +90,9 @@ export class Banner {
 	}
 
 	createBanner() {
+		this.localImpressionCount.incrementImpressionCount();
+		this.templateVars.impression_count = this.localImpressionCount.getImpressionCount();
+
 		this.bannerContainer = document.getElementById( BANNER_CONTAINER_ID );
 		this.bannerContainer.innerHTML = this.template( this.templateVars );
 
@@ -98,7 +100,6 @@ export class Banner {
 
 		document.body.prepend( document.getElementById( CENTRAL_NOTICE_ID ) );
 		this.banner.style.display = 'block';
-		this.localImpressionCount.incrementImpressionCount();
 	}
 
 	registerResizeEvents() {

--- a/wikipedia_aktionswoche/banner_ctrl.js
+++ b/wikipedia_aktionswoche/banner_ctrl.js
@@ -27,7 +27,7 @@ $( document ).ready( () => {
 	const bannerTemplate = require( './templates/banner.hbs' );
 
 	const templateVars = {
-		campaign: bannerName,
+		keyword: bannerName,
 		banner: BANNER_CLASS_PREFIX,
 		banner_title: BANNER_TITLE,
 		banner_subtitle: BANNER_SUBTITLE,

--- a/wikipedia_aktionswoche/banner_var.js
+++ b/wikipedia_aktionswoche/banner_var.js
@@ -27,7 +27,7 @@ $( document ).ready( () => {
 	const bannerTemplate = require( './templates/banner.hbs' );
 
 	const templateVars = {
-		campaign: bannerName,
+		keyword: bannerName,
 		banner: BANNER_CLASS_PREFIX,
 		banner_title: BANNER_TITLE,
 		banner_subtitle: BANNER_SUBTITLE,

--- a/wikipedia_aktionswoche/templates/banner.hbs
+++ b/wikipedia_aktionswoche/templates/banner.hbs
@@ -5,7 +5,7 @@
 			<div class="aktionswoche-banner-close-button"></div>
 		</a>
 	</div>
-	<a id="aktionswoche-banner-link" href="https://www.wikimedia.de/wikipedia20?campaign={{ campaign }}&wp_user={{ wp_user }}&impression_count={{ impression_count }}">
+	<a id="aktionswoche-banner-link" href="https://www.wikimedia.de/wikipedia20?pk_campaign=wp20_aw&pk_kwd={{ keyword }}&wp_user={{ wp_user }}&impression_count={{ impression_count }}">
 		<div class="aktionswoche-banner-inner">
 			<!-- confetti background -->
 			<div class="aktionswoche-banner-illustration" 


### PR DESCRIPTION
To make it work for the campaign start, the order of method calls was changed and another ipad specific campaign was added using the same code, but different campaign parameters.